### PR TITLE
fix(build): add torch to build-system.requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ license-files = ["LICENSE"]
 exclude = ["**/.mypy_cache/**", "**/build/**", "**/.vscode/**"]
 
 [build-system]
-requires = ["scikit-build-core>=0.10", "pybind11>=2.10", "torch==2.9.1"]
+requires = ["scikit-build-core>=0.10", "pybind11>=2.10", "torch==2.10.0"]
 build-backend = "scikit_build_core.build"
 
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ license-files = ["LICENSE"]
 exclude = ["**/.mypy_cache/**", "**/build/**", "**/.vscode/**"]
 
 [build-system]
-requires = ["scikit-build-core>=0.10", "pybind11>=2.10", "cmake", "ninja"]
+requires = ["scikit-build-core>=0.10", "pybind11>=2.10", "torch"]
 build-backend = "scikit_build_core.build"
 
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ license-files = ["LICENSE"]
 exclude = ["**/.mypy_cache/**", "**/build/**", "**/.vscode/**"]
 
 [build-system]
-requires = ["scikit-build-core>=0.10", "pybind11>=2.10", "torch"]
+requires = ["scikit-build-core>=0.10", "pybind11>=2.10", "torch==2.9.1"]
 build-backend = "scikit_build_core.build"
 
 [tool.isort]


### PR DESCRIPTION
## Summary

`CMakeLists.txt` calls `find_package(Torch CONFIG REQUIRED)`, which searches for `TorchConfig.cmake` that ships inside the installed PyTorch package (`<site-packages>/torch/share/cmake/Torch/TorchConfig.cmake`). However, `torch` is missing from `build-system.requires`, so pip/uv's isolated build environment never has torch installed, causing the CMake configuration step to fail:

```
CMake Error at CMakeLists.txt:43 (find_package):
  Could not find a package configuration file provided by "Torch" with any of
  the following names:

    TorchConfig.cmake
    torch-config.cmake
```

Even when the invoking user has torch installed in their venv, pip/uv does not share that environment with the isolated build venv by default, so every `pip install git+https://github.com/tatsy/torchmcubes.git` in a clean env fails.

## Changes

- Add `torch` to `[build-system].requires` so the isolated build env has it available.
- Drop `cmake` and `ninja` from `requires` — `scikit-build-core` already auto-injects them and emits warnings when they are listed explicitly:
  ```
  WARNING - cmake should not be in build-system.requires - scikit-build-core will inject it as needed
  WARNING - ninja should not be in build-system.requires - scikit-build-core will inject it as needed
  ```

## Verification

After this change, `pip install git+https://github.com/tatsy/torchmcubes.git` succeeds in a clean env without any external workaround (no `--no-build-isolation`, no manually prepended `CMAKE_PREFIX_PATH`).