### PR TITLE
build: add torch to build-system.requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ license-files = ["LICENSE"]
 exclude = ["**/.mypy_cache/**", "**/build/**", "**/.vscode/**"]
 
 [build-system]
-requires = ["scikit-build-core>=0.10", "pybind11>=2.10", "cmake", "ninja"]
+requires = ["scikit-build-core>=0.10", "pybind11>=2.10", "cmake", "ninja", "torch"]
 build-backend = "scikit_build_core.build"
 
 [tool.isort]


### PR DESCRIPTION
## Problem

\`CMakeLists.txt\` calls \`find_package(Torch CONFIG REQUIRED)\`, which searches for \`TorchConfig.cmake\` that ships inside the installed PyTorch Python package (\`<site-packages>/torch/share/cmake/Torch/TorchConfig.cmake\`). However, \`torch\` is not declared in \`[build-system].requires\`, so pip/uv's isolated build environment never has torch installed, causing the CMake configuration step to fail in any clean environment:

\`\`\`
CMake Error at CMakeLists.txt:43 (find_package):
  Could not find a package configuration file provided by \"Torch\" with any of
  the following names:

    TorchConfig.cmake
    torch-config.cmake
\`\`\`

Users currently have to either disable build isolation (\`--no-build-isolation\` plus pre-installing torch in the target env) or install from a working local checkout, rather than the simple \`pip install git+https://github.com/tatsy/torchmcubes.git\`.

## Fix

Minimal change: add \`torch\` to the existing \`[build-system].requires\` list. \`cmake\` and \`ninja\` are left untouched to stay consistent with the current project style.

\`\`\`diff
 [build-system]
-requires = [\"scikit-build-core>=0.10\", \"pybind11>=2.10\", \"cmake\", \"ninja\"]
+requires = [\"scikit-build-core>=0.10\", \"pybind11>=2.10\", \"cmake\", \"ninja\", \"torch\"]
\`\`\`

## Verification

After this change, \`pip install git+https://github.com/tatsy/torchmcubes.git\` succeeds in a clean venv without any external workaround (no \`--no-build-isolation\`, no manually prepended \`CMAKE_PREFIX_PATH\`).